### PR TITLE
add missing dependency for sentry 9

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,3 +54,4 @@ parts:
       - python-dev
       - clang
       - build-essential
+      - libxmlsec1-dev


### PR DESCRIPTION
built successfully with "snapcraft cleanbuild"