### PR TITLE
add "cargo" as a build dependency, needed for arm64 and armhf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,3 +55,4 @@ parts:
       - clang
       - build-essential
       - libxmlsec1-dev
+      - cargo


### PR DESCRIPTION
Should progress https://launchpadlibrarian.net/383167570/buildlog_snap_ubuntu_xenial_arm64_17fc91e19f932bd8a75175923b533019-xenial_BUILDING.txt.gz