### PR TITLE
Add sentry plugins

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ parts:
     python-version: python2
     python-packages:
       - sentry==$SNAPCRAFT_PROJECT_VERSION
+      - sentry-plugins==$SNAPCRAFT_PROJECT_VERSION
       - https://github.com/getsentry/sentry-auth-saml2/archive/master.zip
     build-packages:
       - libssl-dev


### PR DESCRIPTION
Sentry plugins are useful enough that they should be enabled by default.

Resolves https://github.com/snapcrafters/sentry/issues/6