### PR TITLE
Fix version number

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: '9.0'
+version: '9.0.0'
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry’s real-time error tracking gives you insight


### PR DESCRIPTION
Fixes the bot we use to determine version number, as upstream call it 9.0.0, not 9.0.