### PR TITLE
Add post-refresh hook to run sentry upgrade

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+sentry upgrade


### PR DESCRIPTION
As per https://docs.sentry.io/server/upgrading/ one needs to run `sentry upgrade` after upgrading, before running services.