### PR TITLE
Fix up post-refresh hook

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,4 +1,6 @@
 #!/bin/bash
-set -eu
+set -u
 set -o pipefail
-$SNAP/command-sentry.wrapper upgrade
+# Try to ensure we have config first
+$SNAP/command-sentry.wrapper config list >/dev/null 
+if [ $? -eq 0 ]; then $SNAP/command-sentry.wrapper upgrade --noinput; else echo "Missing config, doing nothing"; fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eu
 set -o pipefail
-sentry upgrade
+$SNAP/command-sentry.wrapper upgrade


### PR DESCRIPTION
`sentry` is not in the `$PATH` of the snap's `post-refresh` hook, so point to the wrapper explicitly.

Also try to guard against missing config.