### PR TITLE
remove sentry-plugins pip package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,7 +50,6 @@ parts:
     python-version: python2
     python-packages:
       - sentry==$SNAPCRAFT_PROJECT_VERSION
-      - sentry-plugins==$SNAPCRAFT_PROJECT_VERSION
       - https://github.com/getsentry/sentry-auth-saml2/archive/master.zip
       - https://github.com/getsentry/sentry-auth-github/archive/master.zip
     build-packages:


### PR DESCRIPTION
The sentry-plugins are now maintained as part of sentry.

This removes sentry-plugins from the installed pip packages.

Closes #27 