### PR TITLE
Add shared-memory interface with private: true

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,10 @@ architectures:
   - build-on: i386
   - build-on: amd64
 
+plugs:
+  shared-memory:
+    private: true
+
 apps:
   sentry:
     command: bin/sentry


### PR DESCRIPTION
Sentry is attempting to create semaphores in `/dev/shm` which are being
blocked by AppArmor strict confinement.

* Add private shared memory for this snap to alleviate the issue

Fixes #34
Fixes #42
Closes #35 (supercedes)

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>