### PR TITLE
Sentry 22 build fixes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,6 +64,131 @@ parts:
     plugin: python
     python-packages:
       - sentry==$SNAPCRAFT_PROJECT_VERSION
+      # To update for a new version of Sentry, remove the following
+      # and replace with your successful build's "pip freeze" output.
+      - amqp==2.6.1
+      - async-generator==1.10
+      - attrs==19.2.0
+      - beautifulsoup4==4.7.1
+      - billiard==3.6.4.0
+      - boto3==1.22.12
+      - botocore==1.25.12
+      - Brotli==1.0.9
+      - cachetools==4.2.4
+      - celery==4.4.7
+      - certifi==2022.5.18.1
+      - cffi==1.15.1
+      - chardet==4.0.0
+      - click==8.0.4
+      - confluent-kafka==1.9.2
+      - croniter==0.3.37
+      - cryptography==37.0.2
+      - cssselect==1.0.3
+      - cssutils==2.4.0
+      - datadog==0.29.3
+      - decorator==5.1.1
+      - Django==2.2.28
+      - django-crispy-forms==1.14.0
+      - django-pg-zero-downtime-migrations==0.11
+      - djangorestframework==3.12.4
+      - drf-spectacular==0.22.1
+      - email-reply-parser==0.5.12
+      - fido2==0.9.2
+      - google-api-core==1.32.0
+      - google-auth==1.35.0
+      - google-cloud-bigtable==1.6.1
+      - google-cloud-core==1.5.0
+      - google-cloud-functions==1.8.0
+      - google-cloud-pubsub==2.2.0
+      - google-cloud-spanner==3.17.0
+      - google-cloud-storage==1.35.0
+      - google-crc32c==1.3.0
+      - google-resumable-media==1.3.3
+      - googleapis-common-protos==1.56.2
+      - grpc-google-iam-v1==0.12.4
+      - grpcio==1.47.0
+      - h11==0.13.0
+      - hiredis==0.3.1
+      - idna==2.10
+      - inflection==0.5.1
+      - isodate==0.6.1
+      - jmespath==0.10.0
+      - jsonschema==3.2.0
+      - kombu==4.6.11
+      - libcst==0.4.3
+      - lxml==4.6.5
+      - maxminddb==2.0.3
+      - milksnake==0.1.5
+      - mistune==2.0.4
+      - mmh3==3.0.0
+      - msgpack==1.0.4
+      - mypy-extensions==0.4.3
+      - natsort==8.1.0
+      - oauthlib==3.1.0
+      - outcome==1.2.0
+      - packaging==21.3
+      - parsimonious==0.8.0
+      - petname==2.6
+      - phabricator==0.7.0
+      - phonenumberslite==8.12.0
+      - Pillow==9.0.1
+      - progressbar2==3.41.0
+      - proto-plus==1.20.4
+      - protobuf==3.19.0
+      - psycopg2-binary==2.8.6
+      - pyasn1==0.4.5
+      - pyasn1-modules==0.2.4
+      - pycparser==2.21
+      - PyJWT==2.4.0
+      - pyOpenSSL==22.0.0
+      - pyparsing==3.0.9
+      - pyrsistent==0.18.1
+      - PySocks==1.7.1
+      - python-dateutil==2.8.1
+      - python-memcached==1.59
+      - python-rapidjson==1.4
+      - python-u2flib-server==5.0.0
+      - python-utils==3.3.3
+      - python3-saml==1.14.0
+      - pytz==2018.9
+      - PyYAML==5.4
+      - rb==1.9.0
+      - redis==3.4.1
+      - redis-py-cluster==2.1.0
+      - requests==2.25.1
+      - requests-oauthlib==1.2.0
+      - rfc3339-validator==0.1.2
+      - rfc3986-validator==0.1.1
+      - rsa==4.8
+      - s3transfer==0.5.2
+      - selenium==4.3.0
+      - sentry-arroyo==1.0.3
+      - sentry-relay==0.8.13
+      - sentry-sdk==1.9.4
+      - simplejson==3.17.6
+      - six==1.16.0
+      - sniffio==1.2.0
+      - snuba-sdk==1.0.0
+      - sortedcontainers==2.4.0
+      - soupsieve==2.3.2.post1
+      - sqlparse==0.3.0
+      - statsd==3.3.0
+      - structlog==21.1.0
+      - symbolic==8.7.1
+      - toronado==0.1.0
+      - trio==0.21.0
+      - trio-websocket==0.9.2
+      - typing-extensions==3.10.0.2
+      - typing-inspect==0.7.1
+      - ua-parser==0.10.0
+      - unidiff==0.7.4
+      - uritemplate==4.1.1
+      - urllib3==1.26.11
+      - uWSGI==2.0.20
+      - vine==1.3.0
+      - wsproto==1.1.0
+      - xmlsec==1.3.11
+      - zstandard==0.18.0
     build-packages:
       - libssl-dev
       - libffi-dev
@@ -88,4 +213,10 @@ parts:
       - libxmlsec1
       - libxmlsec1-openssl
       - libxslt1.1
-
+    override-build: |
+      set +x
+      snapcraftctl build
+      echo "-==[ BEGIN LOCAL PACKAGES LIST ]==-"
+      # For some reason `--exclude sentry` doesn't work, hence the `grep`!
+      pip3 freeze --local | grep -v ^sentry==
+      echo "-==[  END LOCAL PACKAGES LIST  ]==-"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: '22.8.0'
+version: '22.10.0'
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry’s real-time error tracking gives you insight

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   and fix crashes.
 grade: stable
 confinement: strict
-base: core18
+base: core20
 
 architectures:
   - build-on: i386
@@ -94,16 +94,16 @@ parts:
       - libxmlsec1-dev
       - cargo
       - pkg-config
-      - python3.6-dev
+      - python3.8-dev
       - python3-pip
       - python3-venv
       - libpython3-all-dev
     build-environment:
-      - CPPFLAGS: '$CPPFLAGS -I/usr/include/python3.6m'
-      - CFLAGS: "$CFLAGS -I/usr/include/python3.6m"
+      - CPPFLAGS: '$CPPFLAGS -I/usr/include/python3.8'
+      - CFLAGS: "$CFLAGS -I/usr/include/python3.8"
     stage-packages:
-      - libicu60
-      - libpython3.6
+      - libicu66
+      - libpython3.8
       - libxml2
       - libxmlsec1
       - libxmlsec1-openssl

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: '22.2.0'
+version: '22.8.0'
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry’s real-time error tracking gives you insight

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,26 +63,6 @@ parts:
   sentry:
     plugin: python
     python-packages:
-      - wheel==0.36.2
-      - requests==2.20.0
-      - xmlsec==0.6.1
-      - python-u2flib-server==5.0.1
-      - pyrsistent==0.17.3
-      - grpcio==1.35.0
-      - phabricator==0.6.1
-      - maxminddb==1.5.4
-      - petname==2.6
-      - simplejson==3.11.1
-      - hiredis==0.3.1
-      - PyYAML==5.3.1
-      - mmh3==2.3.1
-      - urllib3==1.24.2
-      - setproctitle==1.1.9
-      - uwsgi==2.0.19.1
-      - parsimonious==0.8.0
-      - grpc-google-iam-v1==0.12.3
-      - googleapis-common-protos==1.52.0
-      - python3-saml==1.4.0
       - sentry==$SNAPCRAFT_PROJECT_VERSION
     build-packages:
       - libssl-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: sentry
 version: '22.10.0'
+epoch: 2
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry’s real-time error tracking gives you insight


### PR DESCRIPTION
This PR updates the snap to build Sentry 22.10.0.

However, I'm marking it as a draft because it's probably not wise to merge. According to the documentation, upgrading from the last working version of the snap, 9.1.2, should not be done directly.  See scenario 2 here: https://develop.sentry.dev/self-hosted/releases/#hard-stops

It's not clear to me how to implement this with snaps.  Certainly the various versions could be published as branches or tracks, but the operator still needs to know to run the upgrades in the given order.

As well as this, I haven't been able to work out a set of dependencies that 21.5.0 will build against. Hopefully this is just something simple I've overlooked.