### PR TITLE
Add version 21.5.0 as the start of the first epoch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Before installing or upgrading, make sure you have the following availiable:
 * Kafka service. (as of 21.5.0)
 * Snuba API service. (as of 21.5.0)
 
-> An example `docker-compose.yml` is included in thi repository, and within the
+> An example `docker-compose.yml` is included in this repository, and within the
 > root directory of the package itself. This is to provide a quick, not suitable
 > for production, way to get the required services running on the same host to
 > test that the snap works.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ distributions.</p>
 
 ## Install
 
-Before installing, make sure you have the following availiable:
+Before installing or upgrading, make sure you have the following availiable:
 
 * Postgres database.
 * Redis database.
+* Clickhouse database. (as of 21.5.0)
+* Zookeeper service. (as of 21.5.0)
+* Kafka service. (as of 21.5.0)
+* Snuba API service. (as of 21.5.0)
+
+> An example `docker-compose.yml` is included in thi repository, and within the
+> root directory of the package itself. This is to provide a quick, not suitable
+> for production, way to get the required services running on the same host to
+> test that the snap works.
 
 Once you have these running, install Sentry with:
 `sudo snap install sentry`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,96 @@
+---
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.5.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
+      KAFKA_OPTS: "-Dzookeeper.4lw.commands.whitelist=ruok"
+    healthcheck:
+      test: ["CMD-SHELL", "echo 'ruok' | nc -w 2 -q 2 localhost 2181 | grep imok"]
+      interval: 30s
+      timeout: 60s
+      retries: 10
+      start_period: 10s
+
+  kafka:
+    image: confluentinc/cp-kafka:5.5.0
+    container_name: kafka
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 1
+      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 9092"]
+      interval: 30s
+      timeout: 60s
+      retries: 10
+      start_period: 10s
+
+  clickhouse:
+    image: yandex/clickhouse-server:20.3.9.70
+    container_name: clickhouse
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD-SHELL", "http_proxy='' wget -nv -t1 --spider 'http://localhost:8123' || exit 1"]
+      interval: 3s
+      timeout: 600s
+      retries: 200
+
+  redis:
+    image: redis:6.2.4-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    ulimits:
+      nofile:
+        soft: 10032
+        hard: 10032
+    healthcheck:
+      test: redis-cli ping
+      interval: 30s
+      timeout: 60s
+      retries: 10
+      start_period: 10s
+
+  snuba:
+    image: getsentry/snuba:21.5.0
+    container_name: snuba
+    ports:
+      - "1218:1218"
+    depends_on:
+      kafka:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      CLICKHOUSE_HOST: clickhouse
+      DEFAULT_BROKERS: 'kafka:9092'
+      REDIS_HOST: redis
+
+  postgres:
+    image: postgres:9.6
+    container_name: postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_DB: sentry
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 30s
+      timeout: 60s
+      retries: 10
+      start_period: 10s

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -u
 set -o pipefail
+
 # Try to ensure we have config first
-$SNAP/command-sentry.wrapper config list >/dev/null 
-if [ $? -eq 0 ]; then $SNAP/command-sentry.wrapper upgrade --noinput; else echo "Missing config, doing nothing"; fi
+$SNAP/bin/sentry config list >/dev/null
+if [ $? -ne 0 ]; then
+    echo "Sentry is not initialised yet, so there is no need to migrate the database."
+    echo "Exiting and allowing the refresh to continue as normal."
+    exit 0
+fi
+
+echo "Migrating the database"
+$SNAP/bin/sentry upgrade --noinput
+echo "Migration complete."

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: sentry
 version: '21.5.0'
-epoch: 1*
+epoch: 1
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry's real-time error tracking gives you insight

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   and fix crashes.
 grade: stable
 confinement: strict
-base: core18
+base: core20
 
 architectures:
   - build-on: i386
@@ -29,18 +29,18 @@ apps:
       - network
       - network-bind
   web:
+    daemon: simple
     command: bin/sentry run web
     environment:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
-    daemon: simple
     plugs:
       - home
       - network
       - network-bind
   worker:
-    command: bin/sentry run worker
     daemon: simple
+    command: bin/sentry run worker
     environment:
       C_FORCE_ROOT: 1
       LANG: C.UTF-8
@@ -64,27 +64,19 @@ parts:
   sentry:
     plugin: python
     python-packages:
-      - wheel==0.36.2
-      - requests==2.20.0
-      - xmlsec==0.6.1
-      - python-u2flib-server==5.0.1
-      - pyrsistent==0.17.3
-      - grpcio==1.35.0
-      - phabricator==0.6.1
-      - maxminddb==1.5.4
-      - petname==2.6
-      - simplejson==3.11.1
-      - hiredis==0.3.1
-      - PyYAML==5.3.1
-      - mmh3==2.3.1
-      - urllib3==1.24.2
-      - setproctitle==1.1.9
-      - uwsgi==2.0.19.1
-      - parsimonious==0.8.0
-      - grpc-google-iam-v1==0.12.3
       - googleapis-common-protos==1.52.0
-      - python3-saml==1.4.0
-      - setuptools-rust>=0.11.4
+      - grpc-google-iam-v1==0.12.3
+      - grpcio==1.35.0
+      - hiredis==0.3.1
+      - lxml==4.6.3
+      - parsimonious==0.8.0
+      - petname==2.6
+      - pyrsistent==0.17.3
+      - setproctitle==1.1.9
+      - urllib3==1.24.2
+      - uwsgi==2.0.19.1
+      - wheel==0.36.2
+      - xmlsec==1.0.5
       - sentry==$SNAPCRAFT_PROJECT_VERSION
     build-packages:
       - libssl-dev
@@ -96,16 +88,13 @@ parts:
       - libxmlsec1-dev
       - cargo
       - pkg-config
-      - python3.6-dev
+      - python3.8-dev
+      - python3.8-venv
       - python3-pip
-      - python3-venv
-      - libpython3-all-dev
-    build-environment:
-      - CPPFLAGS: '$CPPFLAGS -I/usr/include/python3.6m'
-      - CFLAGS: "$CFLAGS -I/usr/include/python3.6m"
+      - libpython3.8-dev
     stage-packages:
-      - libicu60
-      - libpython3.6
+      - libicu66
+      - libpython3.8
       - libxml2
       - libxmlsec1
       - libxmlsec1-openssl

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,10 @@ grade: stable
 confinement: strict
 base: core20
 
+assumes:
+- command-chain
+- snapd2.38 # epochs
+
 architectures:
   - build-on: i386
   - build-on: amd64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -112,3 +112,11 @@ parts:
       - libxmlsec1-openssl
       - libxslt1.1
 
+  docker-compose-yml:
+    plugin: dump
+    source: .
+    override-pull: |
+      snapcraftctl pull
+      sed -Ei "s|(image: getsentry/snuba):.*|\1:${SNAPCRAFT_PROJECT_VERSION}|" docker-compose.yml
+    stage:
+    - docker-compose.yml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: sentry
-version: '22.2.0'
+version: '21.5.0'
+epoch: 1*
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry’s real-time error tracking gives you insight

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: sentry
-version: '21.2.0'
+version: '21.5.0'
+epoch: 1*
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry's real-time error tracking gives you insight

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,14 @@ architectures:
   - build-on: i386
   - build-on: amd64
 
+hooks:
+  post-refresh:
+    plugs:
+      - network # for database migrations
+    command-chain:
+      # maybe not needed/supported when we upgrade to core22
+      - "snap/command-chain/snapcraft-runner"
+
 plugs:
   shared-memory:
     private: true


### PR DESCRIPTION
Following [the hard stops builtin to sentry](https://develop.sentry.dev/self-hosted/releases/#hard-stops).

The current version is 21.2.0. We need to ensure users install 21.5.0 before going further, so I mark that version as the "transitional" release to go beyond.