### PR TITLE
Marking 21.6.3 as the start of the second epoch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: sentry
-version: '22.2.0'
+version: '21.6.3'
+epoch: 2*
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry’s real-time error tracking gives you insight


### PR DESCRIPTION
Continuing on https://github.com/snapcrafters/sentry/pull/46

The transition to the second epoch is version 21.6.3. This should be merged only after https://github.com/snapcrafters/sentry/pull/46 is merged and built.