### PR TITLE
Update version to next hard stop

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: sentry
-version: '21.6.3'
-epoch: 2*
+version: '23.2.6'
+epoch: 3*  # based on https://develop.sentry.dev/self-hosted/releases/#hard-stops
 summary: Sentry is a modern error logging and aggregation platform
 description: |
   Sentry's real-time error tracking gives you insight

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: sentry
-version: '23.2.6'
+version: '23.6.2'
 epoch: 3*  # based on https://develop.sentry.dev/self-hosted/releases/#hard-stops
 summary: Sentry is a modern error logging and aggregation platform
 description: |


### PR DESCRIPTION
based on https://develop.sentry.dev/self-hosted/releases/#hard-stops